### PR TITLE
fix: apply rtl styles for algolia when dir is `rtl` (#628)

### DIFF
--- a/assets/css/rtl.scss
+++ b/assets/css/rtl.scss
@@ -1,23 +1,25 @@
 // Algolia search
-.algolia-wrapper {
-  svg:first-child {
-    margin-right: 0.75rem !important;
-    margin-left: 0 !important;
+html[dir='rtl'] {
+  .algolia-wrapper {
+    svg:first-child {
+      margin-right: 0.75rem !important;
+      margin-left: 0 !important;
+    }
+
+    input#algolia-main {
+      padding-right: 2.5em !important;
+      padding-left: 0 !important;
+      direction: rtl;
+    }
+
+    button[aria-label='Clear input'] {
+      right: unset !important;
+      left: 0 !important;
+    }
   }
 
-  input#algolia-main {
-    padding-right: 2.5em !important;
-    padding-left: 0 !important;;
-    direction: rtl;
+  // Code block switched to ltr
+  .nuxt-content pre {
+    direction: ltr !important;
   }
-
-  button[aria-label="Clear input"] {
-    right: unset !important;
-    left: 0 !important;
-  }
-}
-
-// Code block switched to ltr
-.nuxt-content pre {
-  direction: ltr !important;
 }


### PR DESCRIPTION
* fix: search field display is ruptured

Closes #624

* refactor: handling rlt style using css attribute selector

Thanks to @lecoueyl